### PR TITLE
Rename rc.conf to be suffixed with _enabled and set rcvar service variables

### DIFF
--- a/apply_fix.sh
+++ b/apply_fix.sh
@@ -24,8 +24,8 @@ cat > /etc/rc.conf <<EOM
 
 # Added by DigitalOcean repair script
 cloudinit_enable="YES"
-digitaloceanpre="YES"
-digitalocean="YES"
+digitaloceanpre_enable="YES"
+digitalocean_enable="YES"
 
 $(cat /tmp/rc.conf)
 EOM

--- a/fix/digitalocean
+++ b/fix/digitalocean
@@ -6,6 +6,7 @@
 . /etc/rc.subr
 
 name="digitalocean"
+rcvar="digitalocean_enable"
 start_cmd="${name}_start"
 stop_cmd=":"
 

--- a/fix/digitaloceanpre
+++ b/fix/digitaloceanpre
@@ -7,6 +7,7 @@
 . /etc/rc.subr
 
 name="digitaloceanpre"
+rcvar="digitaloceanpre_enable"
 start_cmd="${name}_start"
 stop_cmd=":"
 


### PR DESCRIPTION
Rename the enable rc variable to something that is suffixed with `_enabled` since this is more typical - also set the `rcvar` variable in the service scripts to make it possible to determine which rc.d variable is controlling them